### PR TITLE
Pyscene speed and precision up

### DIFF
--- a/Scripts/Migliora il Timing Dei Sub/Fase3.py
+++ b/Scripts/Migliora il Timing Dei Sub/Fase3.py
@@ -1,7 +1,9 @@
 import os
 from scenedetect import open_video, SceneManager
-from scenedetect.detectors import AdaptiveDetector, ContentDetector
+from scenedetect.detectors import AdaptiveDetector
 import pysrt
+from concurrent.futures import ThreadPoolExecutor
+from multiprocessing import cpu_count
 
 # Percorso della directory principale del progetto (relativa)
 project_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
@@ -53,46 +55,121 @@ def apply_global_offset_to_srt(input_path, output_path, offset):
         sub.end = apply_offset(sub.end, offset)
     subs.save(output_path, encoding='utf-8')
 
-# Percorso del file video
-video_path = os.path.join(project_path, "ep.mkv")
-if not os.path.exists(video_path):
-    raise FileNotFoundError("Il file video non è stato trovato.")
+# Funzione per trovare i segmenti del video da analizzare basati sui sottotitoli
+def get_segments_to_analyze(srt_path, min_gap=5.0, margin=2.0):
+    subs = pysrt.open(srt_path, encoding='utf-8')
+    segments = []
+    
+    if not subs:
+        return segments
+    
+    # Estendi il primo inizio e l'ultima fine per catturare le scene ai bordi
+    first_start = max(0, subs[0].start.ordinal / 1000 - margin * 2)  # Margine doppio all'inizio
+    last_end = subs[-1].end.ordinal / 1000 + margin * 2  # Margine doppio alla fine
+    
+    current_start = first_start
+    last_end = subs[0].end.ordinal / 1000
+    
+    for i in range(1, len(subs)):
+        current_sub = subs[i]
+        gap = (current_sub.start.ordinal / 1000) - (subs[i-1].end.ordinal / 1000)
+        
+        if gap >= min_gap:
+            # Estendi il segmento corrente con margine abbondante
+            segments.append((current_start, subs[i-1].end.ordinal / 1000 + margin))
+            # Inizia nuovo segmento con margine abbondante
+            current_start = current_sub.start.ordinal / 1000 - margin
+        
+        last_end = current_sub.end.ordinal / 1000
+    
+    # Aggiungi l'ultimo segmento esteso
+    segments.append((current_start, last_end + margin))
+    
+    return segments
 
-# Caricamento del video
-video_manager = open_video(video_path)
+# Funzione per processare un singolo segmento
+def process_segment(args):
+    segment, video_path, adaptive_threshold = args
+    start_time, end_time = segment
+    
+    try:
+        video_manager = open_video(video_path)
+        video_manager.seek(max(0, start_time - 0.5))
+        
+        scene_manager = SceneManager()
+        adaptive_detector = AdaptiveDetector(
+            adaptive_threshold=adaptive_threshold,
+            min_content_val=20
+        )
+        scene_manager.add_detector(adaptive_detector)
+        
+        scene_manager.detect_scenes(video_manager, end_time=end_time + 0.5, show_progress=True)
+        
+        segment_scenes = []
+        for scene in scene_manager.get_scene_list():
+            scene_start = scene[0].get_seconds()
+            scene_end = scene[1].get_seconds()
+            if scene_end > start_time and scene_start < end_time:
+                segment_scenes.append(scene)
+        
+        return segment_scenes
+    except Exception as e:
+        print(f"Errore durante l'elaborazione del segmento {start_time}-{end_time}: {str(e)}")
+        return []
 
-# SceneManager con AdaptiveDetector e ContentDetector
-scene_manager = SceneManager()
-adaptive_detector = AdaptiveDetector(adaptive_threshold=10)
-content_detector = ContentDetector(threshold=29)
-scene_manager.add_detector(adaptive_detector)
-scene_manager.add_detector(content_detector)
+def main():
+    # Percorso del file video
+    video_path = os.path.join(project_path, "ep.mkv")
+    if not os.path.exists(video_path):
+        raise FileNotFoundError("Il file video non è stato trovato.")
 
-# Rileva le scene con progress bar
-print("Analisi delle scene in corso...")
-scene_manager.detect_scenes(video_manager, show_progress=True)
-scene_list = scene_manager.get_scene_list()
+    # Percorso del file SRT dei sottotitoli
+    srt_path = os.path.join(project_path, "adjusted_Sub.srt")
+    if not os.path.exists(srt_path):
+        raise FileNotFoundError("Il file SRT dei sottotitoli non è stato trovato.")
 
-# Esporta i risultati in formato SRT
-srt_output_path = os.path.join(project_path, "scene_timestamps.srt")
-export_srt(scene_list, output_path=srt_output_path)
+    # Ottieni i segmenti del video da analizzare
+    segments = get_segments_to_analyze(srt_path, min_gap=5.0, margin=1.0)
 
-# Calcola la discrepanza costante
-discrepancy = calculate_discrepancy(scene_list, srt_output_path)
+    # Parametri per i detector
+    adaptive_threshold = 3
 
-# Offset possibili
-possible_offsets = [-0.011, -0.021, -0.031, -0.041]
+    # Prepara gli argomenti per il pool
+    process_args = [(segment, video_path, adaptive_threshold) for segment in segments]
 
-# Trova l'offset più vicino
-best_offset = find_closest_offset(discrepancy, possible_offsets)
+    # Rilevamento parallelo delle scene
+    print("Analisi parallela delle scene in corso...")
+    
+    # num_processes
+    num_threads = min(cpu_count(), len(segments)) if segments else 1
+    with ThreadPoolExecutor(max_workers=num_threads) as executor:
+        futures = [executor.submit(process_segment, arg) for arg in process_args]
+        results = [future.result() for future in futures]
 
-# Applica l'offset globale al file SRT
-adjusted_srt_output_path = os.path.join(project_path, "scene_timestamps_adjusted.srt")
-apply_global_offset_to_srt(srt_output_path, adjusted_srt_output_path, best_offset)
+    # Unisci i risultati
+    all_scenes = []
+    for segment_scenes in results:
+        all_scenes.extend(segment_scenes)
+    all_scenes.sort(key=lambda x: x[0].get_seconds())
 
-# Stampa i risultati
-print(f"Scene rilevate: {len(scene_list)}")
-for i, scene in enumerate(scene_list):
-    print(f"Scena {i+1}: Inizio: {scene[0].get_timecode()}, Fine: {scene[1].get_timecode()}")
-print(f"File SRT con offset globale applicato creato con successo: scene_timestamps_adjusted.srt")
-print(f"Offset applicato: {best_offset:.3f} secondi")
+    # Esporta i risultati
+    srt_output_path = os.path.join(project_path, "scene_timestamps.srt")
+    export_srt(all_scenes, output_path=srt_output_path)
+
+    # Calcola e applica offset
+    discrepancy = calculate_discrepancy(all_scenes, srt_output_path)
+    possible_offsets = [-0.011, -0.021, -0.031, -0.041]
+    best_offset = find_closest_offset(discrepancy, possible_offsets)
+    adjusted_srt_output_path = os.path.join(project_path, "scene_timestamps_adjusted.srt")
+    apply_global_offset_to_srt(srt_output_path, adjusted_srt_output_path, best_offset)
+
+    # Stampa risultati
+    print(f"Scene rilevate: {len(all_scenes)}")
+    for i, scene in enumerate(all_scenes):
+        print(f"Scena {i+1}: Inizio: {scene[0].get_timecode()}, Fine: {scene[1].get_timecode()}")
+    print(f"File SRT con offset globale applicato creato con successo: scene_timestamps_adjusted.srt")
+    print(f"Offset applicato: {best_offset:.3f} secondi")
+    print(f"Segmenti analizzati: {segments}")
+
+if __name__ == '__main__':
+    main()

--- a/Scripts/Migliora il Timing Dei Sub/Fase4.py
+++ b/Scripts/Migliora il Timing Dei Sub/Fase4.py
@@ -158,22 +158,55 @@ def adjust_sub_end_based_on_next_scene_change(original_subs, scene_subs):
 
 def adjust_sub_end_based_on_previous_scene_change(original_subs, scene_subs, audio_peaks):
     max_range = 900
-    extra_range_after_scene = 120
-
-    for sub in original_subs:
-        sub_end = sub.end.ordinal
+    peak_threshold = 150  # 150ms per early/late peaks
+    min_gap_to_next_sub = 100
+    min_peaks_count = 2
+    
+    for i, sub in enumerate(original_subs):
+        original_end = sub.end.ordinal
         sub_start = sub.start.ordinal
+        
+        # 1. Controllo gap alla riga successiva
+        next_sub_start = original_subs[i+1].start.ordinal if i+1 < len(original_subs) else float('inf')
+        gap_to_next = next_sub_start - original_end
+        
         for scene in reversed(scene_subs):
             scene_end = scene.end.ordinal
-            if sub_start <= scene_end <= sub_end and 0 < (sub_end - scene_end) <= max_range:
-                peaks_count = 0
-                for peak in audio_peaks:
-                    peak_time = int(peak * 1000)
-                    if scene_end <= peak_time <= sub_end:
-                        peaks_count += 1
-
-                if peaks_count <= 1:
+            
+            if sub_start <= scene_end <= original_end and 0 < (original_end - scene_end) <= max_range:
+                # A. Priorità al gap alla riga successiva
+                if gap_to_next < min_gap_to_next_sub:
                     sub.end = milliseconds_to_subrip_time(scene_end)
+                    break
+                    
+                peak_times = [int(peak * 1000) for peak in audio_peaks]
+                peaks_after_scene = [p for p in peak_times if scene_end <= p <= original_end]
+                
+                # B. Nessun picco -> collega
+                if not peaks_after_scene:
+                    sub.end = milliseconds_to_subrip_time(scene_end)
+                    break
+                
+                # C. NUOVA REGOLA del cazzo (punto 3)
+                early_peaks = [p for p in peaks_after_scene if (p - scene_end) <= peak_threshold]
+                late_peaks = [p for p in peaks_after_scene if (p - scene_end) > peak_threshold]
+                
+                # Solo picchi late (nessun early) ma >=2 -> collega
+                if not early_peaks and len(late_peaks) >= min_peaks_count:
+                    sub.end = milliseconds_to_subrip_time(scene_end)
+                    break
+                
+                # D. Logica dei 2+ picchi
+                if len(peaks_after_scene) >= min_peaks_count:
+                    break
+                
+                # E. ...
+                first_peak_diff = min(peaks_after_scene) - scene_end
+                if first_peak_diff > peak_threshold:
+                    sub.end = milliseconds_to_subrip_time(scene_end)
+                    break
+                    
+                sub.end = milliseconds_to_subrip_time(scene_end)
                 break
 
     return original_subs


### PR DESCRIPTION
Fase3:
- Improved scene change detection and reduced false positives (removed ContentDetector which only caused false positives with almost no benefit).

- Implemented video parallelization in pyscenedetect, making it significantly faster. In short, based on the loaded subtitle lines, it will detect which parts of the video to discard and which parts to feed to pyscenedetect (without cutting the video, it relies on the timing of the lines). Thus, not only does it reduce scene change detection time by not processing the entire video, but the process is also sped up by parallelizing only the relevant video segments.

- Implemented logic to prevent memory leaks during the process.

- The progress bar may now "go crazy" when "Fase3" starts, as multiple video segments are processed simultaneously at high speed, resulting in multiple active progress bars at the same time (this is not an issue if you see this behavior, it's normal).

Fase4:
- Improved the logic of a function that caused issues in previous versions. Now, with the new "Fase3" and the new "Fase4," you'll have fewer lines to adjust in the final file (of course, it’s not perfect and can still make mistakes. Remember that there are configurable values in the GUI adjust them according to your timing preferences).